### PR TITLE
Issue/30 - Test mode admin notice not displayed properly in WP 5.5

### DIFF
--- a/woo-paystack.php
+++ b/woo-paystack.php
@@ -152,6 +152,6 @@ function tbz_wc_paystack_testmode_notice() {
 
 	if ( 'yes' === $test_mode ) {
 		/* translators: 1. Paystack settings page URL link. */
-		echo '<div class="update-nag">' . sprintf( __( 'Paystack test mode is still enabled, Click <strong><a href="%s">here</a></strong> to disable it when you want to start accepting live payment on your site.', 'woo-paystack' ), esc_url( admin_url( 'admin.php?page=wc-settings&tab=checkout&section=paystack' ) ) ) . '</div>';
+		echo '<div class="error"><p>' . sprintf( __( 'Paystack test mode is still enabled, Click <strong><a href="%s">here</a></strong> to disable it when you want to start accepting live payment on your site.', 'woo-paystack' ), esc_url( admin_url( 'admin.php?page=wc-settings&tab=checkout&section=paystack' ) ) ) . '</p></div>';
 	}
 }


### PR DESCRIPTION
Issue: #30