### PR TITLE
Try: Add quick setup settings for gateway recommendations

### DIFF
--- a/includes/class-wc-gateway-paystack.php
+++ b/includes/class-wc-gateway-paystack.php
@@ -1747,4 +1747,23 @@ class WC_Gateway_Paystack extends WC_Payment_Gateway_CC {
 		return $payment_channels;
 	}
 
+	/**
+	 * Get required setting keys for setup.
+	 *
+	 * @return array Array of setting keys used for setup.
+	 */
+	public function get_required_settings_keys() {
+		return array( 'live_public_key', 'live_secret_key' );
+	}
+
+	/**
+	 * Get help text to display during quick setup.
+	 */
+	public function get_setup_help_text() {
+		return sprintf(
+			__( 'Your API details can be obtained from your <a href="%s">Paystack account</a>.', 'woo-paystack' ),
+			'https://dashboard.paystack.com/#/settings/developer'
+		);
+	}
+
 }

--- a/includes/class-wc-gateway-paystack.php
+++ b/includes/class-wc-gateway-paystack.php
@@ -255,6 +255,8 @@ class WC_Gateway_Paystack extends WC_Payment_Gateway_CC {
 		// Webhook listener/API hook.
 		add_action( 'woocommerce_api_tbz_wc_paystack_webhook', array( $this, 'process_webhooks' ) );
 
+		add_filter( 'woocommerce_gateway_' . $this->id . '_settings_values', array( $this, 'update_quick_setup_settings' ) );
+
 		// Check if the gateway can be used.
 		if ( ! $this->is_valid_for_use() ) {
 			$this->enabled = false;
@@ -1764,6 +1766,18 @@ class WC_Gateway_Paystack extends WC_Payment_Gateway_CC {
 			__( 'Your API details can be obtained from your <a href="%s">Paystack account</a>.', 'woo-paystack' ),
 			'https://dashboard.paystack.com/#/settings/developer'
 		);
+	}
+
+	/**
+	 * Updates the currency and test mode when setting up via the quick setup.
+	 */
+	public function update_quick_setup_settings( $settings ) {
+		if ( ! empty( $settings['live_public_key'] ) && ! empty( $settings['live_secret_key'] ) ) {
+			$settings['testmode'] = 'no';
+			update_option( 'woocommerce_currency', 'ZAR' );
+		}
+
+		return $settings;
 	}
 
 }

--- a/includes/class-wc-gateway-paystack.php
+++ b/includes/class-wc-gateway-paystack.php
@@ -255,7 +255,7 @@ class WC_Gateway_Paystack extends WC_Payment_Gateway_CC {
 		// Webhook listener/API hook.
 		add_action( 'woocommerce_api_tbz_wc_paystack_webhook', array( $this, 'process_webhooks' ) );
 
-		add_filter( 'woocommerce_gateway_' . $this->id . '_settings_values', array( $this, 'update_quick_setup_settings' ) );
+		add_filter( 'woocommerce_gateway_' . $this->id . '_settings_values', array( $this, 'update_onboarding_settings' ) );
 
 		// Check if the gateway can be used.
 		if ( ! $this->is_valid_for_use() ) {
@@ -1771,7 +1771,7 @@ class WC_Gateway_Paystack extends WC_Payment_Gateway_CC {
 	/**
 	 * Updates the currency and test mode when setting up via the quick setup.
 	 */
-	public function update_quick_setup_settings( $settings ) {
+	public function update_onboarding_settings( $settings ) {
 		if ( ! empty( $settings['live_public_key'] ) && ! empty( $settings['live_secret_key'] ) ) {
 			$settings['testmode'] = 'no';
 			update_option( 'woocommerce_currency', 'ZAR' );

--- a/includes/class-wc-gateway-paystack.php
+++ b/includes/class-wc-gateway-paystack.php
@@ -1780,4 +1780,13 @@ class WC_Gateway_Paystack extends WC_Payment_Gateway_CC {
 		return $settings;
 	}
 
+	/**
+	 * Determine if the gateway still requires setup.
+	 *
+	 * @return bool
+	 */
+	public function needs_setup() {
+		return ! $this->get_option( 'live_public_key' ) || ! $this->get_option( 'live_secret_key' ) || get_option( 'woocommerce_currency', 'USD' ) !== 'ZAR';
+	}
+
 }


### PR DESCRIPTION
This PR is for testing purposes.  

This is part of the new remote recommended payment gateways feature.  Related PR - https://github.com/woocommerce/woocommerce-admin/pull/7025